### PR TITLE
Add validate claim method for sonic lp position genericFunction call to claim

### DIFF
--- a/src/main.mo
+++ b/src/main.mo
@@ -387,9 +387,9 @@ actor {
 
   };
 
-  // SNS generic function validation method for claim_fees_sonic_lp_position 
-  public query ({ caller }) func validate_claim_fees_sonic_lp_position(
-    position_id : Nat) : async T.ValidationResult {
+  // SNS generic function validation method for claim_fees_lp_position 
+  public query ({ caller }) func validate_claim_fees_lp_position(
+    { position_id : Nat }) : async T.ValidationResult {
 
       let msg:Text = "position_id: " # debug_show(position_id);
 
@@ -397,7 +397,6 @@ actor {
         Principal.toText(caller) # " with arguments: " # msg);
       
       #Ok(msg);
-
   };
 
   // Transfer an ICPSwap LP position owned by this canister.

--- a/src/main.mo
+++ b/src/main.mo
@@ -408,14 +408,14 @@ actor {
       
       #Ok(msg);
   };
-  public query ({ caller }) func validate_withdraw_sonic_lp_position(withdrawArgs: Pool.SonicWithdrawArgs) : async T.ValidationResult {
+  public query ({ caller }) func validate_withdraw_sonic_lp(withdrawArgs: Pool.SonicWithdrawArgs) : async T.ValidationResult {
 
       let msg:Text = 
         "token: " # debug_show(withdrawArgs.token) #
         ", fee: " # debug_show(withdrawArgs.fee) #
         ", amount: " # debug_show(withdrawArgs.amount);
 
-      log_msg("validate_withdraw_sonic_lp_position called by " # 
+      log_msg("validate_withdraw_sonic_lp called by " # 
         Principal.toText(caller) # " with arguments: " # msg);
       
       #Ok(msg);

--- a/src/main.mo
+++ b/src/main.mo
@@ -387,6 +387,19 @@ actor {
 
   };
 
+  // SNS generic function validation method for claim_fees_sonic_lp_position 
+  public query ({ caller }) func validate_claim_fees_sonic_lp_position(
+    position_id : Nat) : async T.ValidationResult {
+
+      let msg:Text = "position_id: " # debug_show(position_id);
+
+      log_msg("validate_claim_fees_sonic_lp_position called by " # 
+        Principal.toText(caller) # " with arguments: " # msg);
+      
+      #Ok(msg);
+
+  };
+
   // Transfer an ICPSwap LP position owned by this canister.
   // This method may only be called by the Sneed DAO Governance Canister, via approved DAO proposal.
   public shared ({ caller }) func transfer_icpex_lp_position(

--- a/src/main.mo
+++ b/src/main.mo
@@ -11,6 +11,7 @@ import Error "mo:base/Error";
 import Debug "mo:base/Debug";
 
 import T "Types";
+import Pool "poolTypes";
 
 actor {
 
@@ -387,13 +388,34 @@ actor {
 
   };
 
-  // SNS generic function validation method for claim_fees_lp_position 
-  public query ({ caller }) func validate_claim_fees_lp_position(
-    { position_id : Nat }) : async T.ValidationResult {
+  // SNS generic function validation method for LP management 
+  public query ({ caller }) func validate_claim_fees_lp_position(claimArgs: Pool.ClaimArgs) : async T.ValidationResult {
 
-      let msg:Text = "position_id: " # debug_show(position_id);
+      let msg:Text = "positionId: " # debug_show(claimArgs.positionId);
 
       log_msg("validate_claim_fees_sonic_lp_position called by " # 
+        Principal.toText(caller) # " with arguments: " # msg);
+      
+      #Ok(msg);
+  };
+  public query ({ caller }) func validate_decrease_liquidity_lp_position(decreaseLiquidityArgs: Pool.DecreaseLiquidityArgs) : async T.ValidationResult {
+
+      let msg:Text = "positionId: " # debug_show(decreaseLiquidityArgs.positionId) #
+        ", liquidity: " # debug_show(decreaseLiquidityArgs.liquidity);
+
+      log_msg("validate_decrease_liquidity_lp_position called by " # 
+        Principal.toText(caller) # " with arguments: " # msg);
+      
+      #Ok(msg);
+  };
+  public query ({ caller }) func validate_withdraw_lp_position(withdrawArgs: Pool.WithdrawArgs) : async T.ValidationResult {
+
+      let msg:Text = 
+        "token: " # debug_show(withdrawArgs.token) #
+        ", fee: " # debug_show(withdrawArgs.fee) #
+        ", amount: " # debug_show(withdrawArgs.amount);
+
+      log_msg("validate_withdraw_lp_position called by " # 
         Principal.toText(caller) # " with arguments: " # msg);
       
       #Ok(msg);

--- a/src/main.mo
+++ b/src/main.mo
@@ -389,7 +389,7 @@ actor {
   };
 
   // SNS generic function validation method for LP management 
-  public query ({ caller }) func validate_claim_fees_lp_position(claimArgs: Pool.ClaimArgs) : async T.ValidationResult {
+  public query ({ caller }) func validate_claim_fees_sonic_lp_position(claimArgs: Pool.SonicClaimArgs) : async T.ValidationResult {
 
       let msg:Text = "positionId: " # debug_show(claimArgs.positionId);
 
@@ -398,24 +398,24 @@ actor {
       
       #Ok(msg);
   };
-  public query ({ caller }) func validate_decrease_liquidity_lp_position(decreaseLiquidityArgs: Pool.DecreaseLiquidityArgs) : async T.ValidationResult {
+  public query ({ caller }) func validate_decrease_liquidity_sonic_lp_position(decreaseLiquidityArgs: Pool.SonicDecreaseLiquidityArgs) : async T.ValidationResult {
 
       let msg:Text = "positionId: " # debug_show(decreaseLiquidityArgs.positionId) #
         ", liquidity: " # debug_show(decreaseLiquidityArgs.liquidity);
 
-      log_msg("validate_decrease_liquidity_lp_position called by " # 
+      log_msg("validate_decrease_liquidity_sonic_lp_position called by " # 
         Principal.toText(caller) # " with arguments: " # msg);
       
       #Ok(msg);
   };
-  public query ({ caller }) func validate_withdraw_lp_position(withdrawArgs: Pool.WithdrawArgs) : async T.ValidationResult {
+  public query ({ caller }) func validate_withdraw_sonic_lp_position(withdrawArgs: Pool.SonicWithdrawArgs) : async T.ValidationResult {
 
       let msg:Text = 
         "token: " # debug_show(withdrawArgs.token) #
         ", fee: " # debug_show(withdrawArgs.fee) #
         ", amount: " # debug_show(withdrawArgs.amount);
 
-      log_msg("validate_withdraw_lp_position called by " # 
+      log_msg("validate_withdraw_sonic_lp_position called by " # 
         Principal.toText(caller) # " with arguments: " # msg);
       
       #Ok(msg);

--- a/src/poolTypes.mo
+++ b/src/poolTypes.mo
@@ -1,0 +1,16 @@
+module {
+    public type ClaimArgs = {
+        positionId: Nat;
+    };
+
+    public type DecreaseLiquidityArgs = {
+        liquidity: Text;
+        positionId: Nat;
+    };
+
+    public type WithdrawArgs = {
+        fee: Nat;
+        token: Text;
+        amount: Nat;
+    };
+}

--- a/src/poolTypes.mo
+++ b/src/poolTypes.mo
@@ -1,4 +1,11 @@
 module {
+    public type SonicClaimArgs = ClaimArgs;
+    public type SonicDecreaseLiquidityArgs = DecreaseLiquidityArgs;
+    public type SonicWithdrawArgs = WithdrawArgs;
+    
+    public type ICPSwapClaimArgs = ClaimArgs;
+    public type ICPSwapWithdrawArgs = WithdrawArgs;
+
     public type ClaimArgs = {
         positionId: Nat;
     };


### PR DESCRIPTION
Candid signatures of sonic canister methods we are validating:

withdraw: (record {fee:nat; token:text; amount:nat}) → (variant {ok:nat; err:variant {CommonError; InternalError:text; UnsupportedToken:text; InsufficientFunds}}) 

claim: (record {positionId:nat}) → (variant {ok:record {amount0:nat; amount1:nat}; err:variant {CommonError; InternalError:text; UnsupportedToken:text; InsufficientFunds}}) 

decreaseLiquidity: (record {liquidity:text; positionId:nat}) → (variant {ok:record {amount0:nat; amount1:nat}; err:variant {CommonError; InternalError:text; UnsupportedToken:text; InsufficientFunds}}) 