### PR TITLE
Add icpswap lp management

### DIFF
--- a/src/Types.mo
+++ b/src/Types.mo
@@ -62,3 +62,21 @@ type TransferICPexLPResult = {
     #Err :Text;
 };
 
+type EmergencyPullSummary = {
+    token0 : Text;
+    token1 : Text;
+    claimed0 : Nat;
+    claimed1 : Nat;
+    liquidity_removed : Nat;
+    decreased0 : Nat;
+    decreased1 : Nat;
+    withdrawn0 : Nat;
+    withdrawn1 : Nat;
+    errors : [Text];
+};
+
+type EmergencyPullResult = {
+    #ok : EmergencyPullSummary;
+    #err : Text;
+};
+

--- a/src/Types.mo
+++ b/src/Types.mo
@@ -80,3 +80,50 @@ type EmergencyPullResult = {
     #err : Text;
 };
 
+// Minimal ICRC1 ledger interface: read the fee, snapshot a balance, and
+// forward a transfer. Used by the LP fee harvester to route claimed fees.
+type ICRC1Ledger = actor {
+    icrc1_fee : () -> async Balance;
+    icrc1_balance_of : (Account) -> async Balance;
+    icrc1_transfer : (TransferArgs) -> async TransferResult;
+};
+
+// A liquidity position enrolled in automatic fee harvesting, identified by
+// its pool (swap canister) and the ICPSwap position id within that pool.
+type ClaimPosition = {
+    pool : Principal;
+    position_id : Nat;
+};
+
+// Result of one harvest cycle. Logged and returned so operators can see
+// exactly what moved. `errors` lists per-step failures; empty when clean.
+//
+// Because ICPSwap's withdraw settles out of band, withdrawing and forwarding
+// are decoupled: a cycle first forwards what earlier cycles withdrew (now
+// settled), then withdraws this cycle's fees into the forward queue. The
+// `pending_*` counters carry the queue between cycles (and across upgrades).
+type HarvestSummary = {
+    positions_seen : Nat;         // enrolled positions considered this cycle
+    positions_harvested : Nat;    // positions where at least one token was withdrawn
+    withdrawn_icp : Nat;          // net ICP added to the forward queue this cycle
+    withdrawn_sneed : Nat;        // net SNEED added to the forward queue this cycle
+    forwarded_icp : Nat;          // ICP sent to the ICP vector this cycle (net of fee)
+    forwarded_sneed : Nat;        // SNEED sent to the SNEED vector this cycle (net of fee)
+    pending_icp : Nat;            // ICP still queued for forwarding after this cycle
+    pending_sneed : Nat;          // SNEED still queued for forwarding after this cycle
+    icp_forward_tx : ?TxIndex;    // ledger tx index of the ICP forward, if it happened
+    sneed_forward_tx : ?TxIndex;  // ledger tx index of the SNEED forward, if it happened
+    errors : [Text];
+};
+
+// Read-only view of the current harvest schedule, forward queue and positions.
+type ClaimConfigView = {
+    active : Bool;
+    cadence_seconds : Nat;
+    min_icp : Balance;
+    min_sneed : Balance;
+    pending_icp : Balance;        // ICP withdrawn but not yet forwarded
+    pending_sneed : Balance;      // SNEED withdrawn but not yet forwarded
+    positions : [ClaimPosition];
+};
+

--- a/src/main.mo
+++ b/src/main.mo
@@ -9,6 +9,7 @@ import List "mo:core/List";
 import Time "mo:core/Time";
 import Principal "mo:core/Principal";
 import Error "mo:core/Error";
+import Timer "mo:core/Timer";
 
 import T "Types";
 import Pool "poolTypes";
@@ -37,6 +38,54 @@ persistent actor {
     let c = Principal.toText(caller);
     c == sneed_governance_id or Array.find<Text>(safety_admins, func(a) { a == c }) != null;
   };
+
+  // === LP fee harvesting: constants ===
+  //
+  // Ledger ids for the two tokens we route. A pool's token0/token1 are matched
+  // against these by EXACT address, so only genuine SNEED/ICP fees are moved.
+  transient let icp_ledger_id = "ryjl3-tyaaa-aaaaa-aaaba-cai";
+  transient let sneed_ledger_id = "hvgxa-wqaaa-aaaaq-aacia-cai";
+
+  // Sneed "RLL" neuron-pool-vector destinations. These are the ONLY places the
+  // harvester can send funds, and they are compile-time constants: no caller
+  // (not even a safety_admin) can change where fees go. The subaccounts were
+  // decoded from the ICRC-1 extended textual form and their checksums verified.
+  //   ICP:   6jvpj-...-azwnq-cai-m7u3kpi.100000000060...0  (subaccount byte 5 = 6)
+  //   SNEED: 6jvpj-...-azwnq-cai-vilbrxq.1000000002d0...0  (subaccount byte 5 = 0x2d = 45)
+  transient let rll_vector_owner = Principal.fromText("6jvpj-sqaaa-aaaaj-azwnq-cai");
+  transient let rll_icp_subaccount : Blob = Blob.fromArray([1, 0, 0, 0, 0, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+  transient let rll_sneed_subaccount : Blob = Blob.fromArray([1, 0, 0, 0, 0, 45, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+  transient let rll_icp_dest : T.Account = { owner = rll_vector_owner; subaccount = ?rll_icp_subaccount };
+  transient let rll_sneed_dest : T.Account = { owner = rll_vector_owner; subaccount = ?rll_sneed_subaccount };
+
+  // Smallest cadence we accept. Timer resolution is roughly the block rate, so a
+  // sub-minute cadence buys nothing and risks hammering the pool/ledgers.
+  transient let min_cadence_seconds = 60;
+
+  // === LP fee harvesting: state ===
+  //
+  // Stable (persistent actor => non-transient vars persist across upgrades):
+  var claim_positions : [T.ClaimPosition] = [];  // positions enrolled in auto-harvest
+  var claim_cadence_seconds : Nat = 0;           // configured cadence (0 until first schedule)
+  var claim_min_icp : Nat = 0;                   // per-token minimum before ICP is forwarded
+  var claim_min_sneed : Nat = 0;                 // per-token minimum before SNEED is forwarded
+  var claim_active : Bool = false;               // whether a recurring harvest is scheduled
+
+  // Forward queue: fees withdrawn from pools but not yet forwarded to the RLL
+  // vectors. ICPSwap's withdraw settles out of band, so a cycle forwards what
+  // earlier cycles withdrew (now settled) rather than its own withdrawals. Kept
+  // stable so in-flight proceeds survive upgrades and are never stranded.
+  var pending_forward_icp : Nat = 0;
+  var pending_forward_sneed : Nat = 0;
+
+  // Transient: timer ids do not survive upgrades; re-armed in postupgrade.
+  transient var claim_timer_id : ?Nat = null;
+
+  // Transient reentrancy guard: never run two harvest cycles at once (a slow
+  // cycle overlapping the next tick, or a manual run racing the timer, would
+  // double-forward the pending queue). do_harvest is trap-free, so this is
+  // always reset; an upgrade also clears it.
+  transient var harvest_running : Bool = false;
 
   // Deploy the specified amount of ICRC1 tokens from the DeFi canistyer (using the null subaccount).
   // Can only be called by the Sneed DAO governance canister (via approved proposal)!
@@ -1071,6 +1120,461 @@ persistent actor {
 
   };
 
+  // ============================================================================
+  // LP fee harvesting -> RLL routing
+  //
+  // On a timer, claim SNEED/ICP fees from enrolled ICPSwap positions this
+  // canister owns and forward each token to its hardcoded Sneed RLL vector.
+  // Funds can ONLY ever reach the two compile-time RLL destinations, so the
+  // schedule/position controls are safe to expose to safety_admins: no caller
+  // input can change where fees go, only which pools are harvested and how often.
+  // ============================================================================
+
+  // Build a HarvestSummary that carries only an error (used to reject a call
+  // in-band without moving any funds). Reports the current forward queue.
+  private func err_summary(msg : Text) : T.HarvestSummary {
+    {
+      positions_seen = 0;
+      positions_harvested = 0;
+      withdrawn_icp = 0;
+      withdrawn_sneed = 0;
+      forwarded_icp = 0;
+      forwarded_sneed = 0;
+      pending_icp = pending_forward_icp;
+      pending_sneed = pending_forward_sneed;
+      icp_forward_tx = null;
+      sneed_forward_tx = null;
+      errors = [msg];
+    };
+  };
+
+  // Forward up to `pending` of `token` to `dest`, capped by the canister's real
+  // balance so emergency/governance funds parked on this canister are never
+  // routed. Returns (forwarded_net, tx, remaining_pending). Best-effort: on any
+  // failure nothing is decremented and the queue is retried next cycle.
+  private func forward_pending(
+    ledger : T.ICRC1Ledger,
+    dest : T.Account,
+    fee : Nat,
+    pending : Nat,
+    label_ : Text,
+    errors : List.List<Text>)
+    : async (Nat, ?Nat, Nat) {
+
+    if (pending <= fee) { return (0, null, pending) };
+
+    let self_account : T.Account = { owner = Principal.fromText(sneed_defi_id); subaccount = null };
+    let bal : ?Nat =
+      try { ?(await ledger.icrc1_balance_of(self_account)) }
+      catch e { List.add(errors, "balance_of(" # label_ # ") failed: " # Error.message(e)); null };
+
+    switch (bal) {
+      case (?b) {
+        // Only ever move what we have accounted as harvested AND what is really
+        // present. `usable` <= pending, so the saturating subtraction can never
+        // underflow the queue.
+        let usable = Nat.min(pending, b);
+        if (usable <= fee) { return (0, null, pending) };
+        let send_amount = usable - fee : Nat;
+        let res : T.TransferResult =
+          try {
+            await ledger.icrc1_transfer({
+              from_subaccount = null;
+              to = dest;
+              amount = send_amount;
+              fee = ?fee;
+              memo = null;
+              created_at_time = null;
+            })
+          } catch e { #Err(#GenericError({ error_code = 1; message = Error.message(e) })) };
+        switch (res) {
+          case (#Ok(tx)) { (send_amount, ?tx, if (pending >= usable) { pending - usable : Nat } else { 0 }) };
+          case (#Err(e)) { List.add(errors, "forward(" # label_ # ") failed: " # debug_show(e)); (0, null, pending) };
+        };
+      };
+      case null { (0, null, pending) };
+    };
+  };
+
+  // Core harvest logic. Best-effort and trap-free: one failing position or
+  // ledger call never aborts the cycle; every failure is recorded in the
+  // summary. No caller gate (internal): reached only via the safety-admin
+  // public wrapper or the recurring timer.
+  //
+  // ICPSwap's withdraw settles OUT OF BAND (it enqueues the transfer and
+  // returns before the tokens arrive), so withdraw and forward are decoupled
+  // across cycles via the stable `pending_forward_*` queue:
+  //   1. FORWARD what earlier cycles withdrew — those proceeds have had >= one
+  //      cadence to settle onto this canister. Capped by real balance so
+  //      commingled emergency/governance funds are never routed.
+  //   2. WITHDRAW this cycle's fees: per position, identify ICP/SNEED sides by
+  //      exact ledger match, claim into the unused balance, then withdraw each
+  //      token whose accumulated unused balance clears its threshold, adding the
+  //      expected net (avail - fee) to the forward queue.
+  private func do_harvest() : async T.HarvestSummary {
+
+    // Reentrancy guard: never overlap two cycles (would double-drain the queue).
+    if (harvest_running) {
+      log_msg("do_harvest skipped: a harvest is already in progress");
+      return err_summary("harvest already in progress; skipped");
+    };
+    harvest_running := true;
+
+    let self = Principal.fromText(sneed_defi_id);
+    let errors = List.empty<Text>();
+
+    let icp_ledger : T.ICRC1Ledger = actor (icp_ledger_id);
+    let sneed_ledger : T.ICRC1Ledger = actor (sneed_ledger_id);
+
+    // Ledger fees (best-effort). A token whose fee is unreadable is neither
+    // forwarded nor withdrawn this cycle; its queue/fees carry to a later run.
+    let icp_fee : ?Nat =
+      try { ?(await icp_ledger.icrc1_fee()) }
+      catch e { List.add(errors, "icrc1_fee(ICP) failed: " # Error.message(e)); null };
+    let sneed_fee : ?Nat =
+      try { ?(await sneed_ledger.icrc1_fee()) }
+      catch e { List.add(errors, "icrc1_fee(SNEED) failed: " # Error.message(e)); null };
+
+    // === 1. Forward phase: drain the (now-settled) queue to the RLL vectors. ===
+    var forwarded_icp : Nat = 0;
+    var forwarded_sneed : Nat = 0;
+    var icp_forward_tx : ?Nat = null;
+    var sneed_forward_tx : ?Nat = null;
+
+    switch (icp_fee) {
+      case (?f) {
+        let (sent, tx, remaining) =
+          await forward_pending(icp_ledger, rll_icp_dest, f, pending_forward_icp, "ICP", errors);
+        forwarded_icp := sent;
+        icp_forward_tx := tx;
+        pending_forward_icp := remaining;
+      };
+      case null {};
+    };
+    switch (sneed_fee) {
+      case (?f) {
+        let (sent, tx, remaining) =
+          await forward_pending(sneed_ledger, rll_sneed_dest, f, pending_forward_sneed, "SNEED", errors);
+        forwarded_sneed := sent;
+        sneed_forward_tx := tx;
+        pending_forward_sneed := remaining;
+      };
+      case null {};
+    };
+
+    // === 2. Withdraw phase: claim fees and queue this cycle's proceeds. ===
+    var positions_seen : Nat = 0;
+    var positions_harvested : Nat = 0;
+    var withdrawn_icp : Nat = 0;
+    var withdrawn_sneed : Nat = 0;
+
+    label nextpos for (cp in claim_positions.vals()) {
+      positions_seen += 1;
+      let pool : Pool.ICPSwapPool = actor (Principal.toText(cp.pool));
+
+      // Identify which side is ICP and which is SNEED by EXACT ledger match.
+      // Anything that is not exactly a SNEED/ICP pool is skipped (never route
+      // an unrecognised token).
+      let meta : Pool.ICPSwapMetadataResult =
+        try { await pool.metadata() }
+        catch e { #err(#InternalError(Error.message(e))) };
+      let icp_is_token0 = switch (meta) {
+        case (#ok(m)) {
+          if (m.token0.address == icp_ledger_id and m.token1.address == sneed_ledger_id) { true }
+          else if (m.token0.address == sneed_ledger_id and m.token1.address == icp_ledger_id) { false }
+          else {
+            List.add(errors, "position " # debug_show(cp.position_id) # " on " #
+              Principal.toText(cp.pool) # " is not a SNEED/ICP pool; skipped");
+            continue nextpos;
+          };
+        };
+        case (#err(e)) {
+          List.add(errors, "metadata failed for " # Principal.toText(cp.pool) #
+            " position " # debug_show(cp.position_id) # ": " # debug_show(e));
+          continue nextpos;
+        };
+      };
+
+      // Claim accrued fees into this canister's unused balance (no ledger fee).
+      // The unused balance is the accumulator: sub-threshold fees pile up here.
+      let claim_res : Pool.ICPSwapAmountsResult =
+        try { await pool.claim({ positionId = cp.position_id }) }
+        catch e { #err(#InternalError(Error.message(e))) };
+      switch (claim_res) {
+        case (#ok(_)) {};
+        case (#err(e)) {
+          List.add(errors, "claim failed for " # Principal.toText(cp.pool) #
+            " position " # debug_show(cp.position_id) # ": " # debug_show(e));
+        };
+      };
+
+      // Read accumulated unused balance and pool reserves to cap each withdraw.
+      let unused : Pool.ICPSwapUnusedBalanceResult =
+        try { await pool.getUserUnusedBalance(self) }
+        catch e { #err(#InternalError(Error.message(e))) };
+      let unused_bal : ?Pool.ICPSwapUnusedBalance = switch (unused) {
+        case (#ok(b)) { ?b };
+        case (#err(e)) {
+          List.add(errors, "getUserUnusedBalance failed for " # Principal.toText(cp.pool) #
+            " position " # debug_show(cp.position_id) # ": " # debug_show(e));
+          null;
+        };
+      };
+      let held : ?Pool.ICPSwapTokenBalance =
+        try { ?(await pool.getTokenBalance()) }
+        catch e {
+          List.add(errors, "getTokenBalance failed for " # Principal.toText(cp.pool) # ": " # Error.message(e));
+          null;
+        };
+
+      switch (unused_bal, held) {
+        case (?u, ?h) {
+          // Map the pool's (balance0/1, token0/1) onto the ICP/SNEED sides.
+          let icp_unused   = if (icp_is_token0) { u.balance0 } else { u.balance1 };
+          let sneed_unused = if (icp_is_token0) { u.balance1 } else { u.balance0 };
+          let icp_held     = if (icp_is_token0) { h.token0 } else { h.token1 };
+          let sneed_held   = if (icp_is_token0) { h.token1 } else { h.token0 };
+
+          var withdrew = false;
+
+          // ICP side: withdraw only when the accumulated unused balance clears
+          // its threshold (and exceeds the fee). Below threshold => leave it to
+          // keep accruing in the pool for a later cycle. On success, queue the
+          // expected net (avail - fee) for forwarding once it settles.
+          switch (icp_fee) {
+            case (?f) {
+              let avail = Nat.min(icp_unused, icp_held);
+              if (avail >= claim_min_icp and avail > f) {
+                let w : Pool.ICPSwapNatResult =
+                  try { await pool.withdraw({ token = icp_ledger_id; fee = f; amount = avail }) }
+                  catch e { #err(#InternalError(Error.message(e))) };
+                switch (w) {
+                  case (#ok(_)) {
+                    let net = avail - f : Nat;
+                    withdrawn_icp += net;
+                    pending_forward_icp += net;
+                    withdrew := true;
+                  };
+                  case (#err(e)) {
+                    List.add(errors, "withdraw(ICP) failed for " # Principal.toText(cp.pool) #
+                      " position " # debug_show(cp.position_id) # ": " # debug_show(e));
+                  };
+                };
+              };
+            };
+            case null {};
+          };
+
+          // SNEED side (same rule).
+          switch (sneed_fee) {
+            case (?f) {
+              let avail = Nat.min(sneed_unused, sneed_held);
+              if (avail >= claim_min_sneed and avail > f) {
+                let w : Pool.ICPSwapNatResult =
+                  try { await pool.withdraw({ token = sneed_ledger_id; fee = f; amount = avail }) }
+                  catch e { #err(#InternalError(Error.message(e))) };
+                switch (w) {
+                  case (#ok(_)) {
+                    let net = avail - f : Nat;
+                    withdrawn_sneed += net;
+                    pending_forward_sneed += net;
+                    withdrew := true;
+                  };
+                  case (#err(e)) {
+                    List.add(errors, "withdraw(SNEED) failed for " # Principal.toText(cp.pool) #
+                      " position " # debug_show(cp.position_id) # ": " # debug_show(e));
+                  };
+                };
+              };
+            };
+            case null {};
+          };
+
+          if (withdrew) { positions_harvested += 1 };
+        };
+        case (_, _) {}; // unused balance or reserves unavailable; errors already recorded
+      };
+    };
+
+    let summary : T.HarvestSummary = {
+      positions_seen = positions_seen;
+      positions_harvested = positions_harvested;
+      withdrawn_icp = withdrawn_icp;
+      withdrawn_sneed = withdrawn_sneed;
+      forwarded_icp = forwarded_icp;
+      forwarded_sneed = forwarded_sneed;
+      pending_icp = pending_forward_icp;
+      pending_sneed = pending_forward_sneed;
+      icp_forward_tx = icp_forward_tx;
+      sneed_forward_tx = sneed_forward_tx;
+      errors = List.toArray(errors);
+    };
+
+    harvest_running := false;
+
+    log_msg("do_harvest completed: " # debug_show(summary));
+    summary;
+  };
+
+  // Recurring timer job. Runs the harvest and discards the summary (it is
+  // logged inside do_harvest).
+  private func harvest_timer_job() : async () {
+    ignore await do_harvest();
+  };
+
+  // Run one harvest immediately. Safety-admin gated. Useful for a manual sweep
+  // or to test the routing without touching the schedule.
+  public shared ({ caller }) func claim_and_route_lp_fees() : async T.HarvestSummary {
+
+    log_msg("claim_and_route_lp_fees called by " # Principal.toText(caller));
+
+    if (not is_safety_admin(caller)) {
+      let err_msg = "claim_and_route_lp_fees ERROR: Not authorized (Was called by " #
+        Principal.toText(caller) # ")";
+      log_msg(err_msg);
+      return err_summary(err_msg);
+    };
+
+    await do_harvest();
+  };
+
+  // (Re)configure the recurring harvest. Safety-admin gated. Cancels any
+  // existing timer, runs one harvest immediately, then arms a recurring timer
+  // at the given cadence with the given per-token minimum thresholds.
+  public shared ({ caller }) func set_lp_fee_claim_schedule(
+    cadence_seconds : Nat,        // how often to harvest, in seconds (>= 60)
+    min_icp : T.Balance,          // minimum accumulated ICP before it is forwarded
+    min_sneed : T.Balance)        // minimum accumulated SNEED before it is forwarded
+    : async T.HarvestSummary {
+
+    log_msg("set_lp_fee_claim_schedule called by " # Principal.toText(caller) #
+      " with arguments: cadence_seconds: " # debug_show(cadence_seconds) #
+      ", min_icp: " # debug_show(min_icp) #
+      ", min_sneed: " # debug_show(min_sneed));
+
+    if (not is_safety_admin(caller)) {
+      let err_msg = "set_lp_fee_claim_schedule ERROR: Not authorized (Was called by " #
+        Principal.toText(caller) # ")";
+      log_msg(err_msg);
+      return err_summary(err_msg);
+    };
+
+    if (cadence_seconds < min_cadence_seconds) {
+      let err_msg = "set_lp_fee_claim_schedule ERROR: cadence_seconds " # debug_show(cadence_seconds) #
+        " is below the minimum of " # debug_show(min_cadence_seconds);
+      log_msg(err_msg);
+      return err_summary(err_msg);
+    };
+
+    // Stop any previously configured timer.
+    switch (claim_timer_id) {
+      case (?id) { Timer.cancelTimer(id); claim_timer_id := null };
+      case null {};
+    };
+
+    // Record the new schedule/thresholds so the immediate run and the recurring
+    // timer both use them.
+    claim_cadence_seconds := cadence_seconds;
+    claim_min_icp := min_icp;
+    claim_min_sneed := min_sneed;
+    claim_active := true;
+
+    // Run one harvest now, then arm the recurring timer.
+    let summary = await do_harvest();
+
+    claim_timer_id := ?Timer.recurringTimer<system>(#seconds cadence_seconds, harvest_timer_job);
+
+    log_msg("set_lp_fee_claim_schedule armed recurring harvest every " #
+      debug_show(cadence_seconds) # "s");
+
+    summary;
+  };
+
+  // Stop the recurring harvest. Safety-admin gated. Leaves the cadence,
+  // thresholds and enrolled positions intact so it can be resumed later.
+  public shared ({ caller }) func stop_lp_fee_claim_schedule() : async () {
+
+    log_msg("stop_lp_fee_claim_schedule called by " # Principal.toText(caller));
+
+    assert is_safety_admin(caller);
+
+    switch (claim_timer_id) {
+      case (?id) { Timer.cancelTimer(id); claim_timer_id := null };
+      case null {};
+    };
+    claim_active := false;
+
+    log_msg("stop_lp_fee_claim_schedule: recurring harvest stopped");
+  };
+
+  // Enroll a position in automatic fee harvesting. Safety-admin gated.
+  // Idempotent: adding an already-enrolled (pool, position_id) is a no-op.
+  public shared ({ caller }) func add_lp_fee_claim_position(
+    pool : Principal,
+    position_id : Nat)
+    : async [T.ClaimPosition] {
+
+    log_msg("add_lp_fee_claim_position called by " # Principal.toText(caller) #
+      " with arguments: pool: " # Principal.toText(pool) #
+      ", position_id: " # debug_show(position_id));
+
+    assert is_safety_admin(caller);
+
+    let exists = Array.find<T.ClaimPosition>(claim_positions, func(p) {
+      Principal.equal(p.pool, pool) and p.position_id == position_id
+    }) != null;
+
+    if (not exists) {
+      claim_positions := Array.concat<T.ClaimPosition>(
+        claim_positions, [{ pool = pool; position_id = position_id }]);
+      log_msg("add_lp_fee_claim_position: enrolled " # Principal.toText(pool) #
+        " position " # debug_show(position_id));
+    };
+
+    claim_positions;
+  };
+
+  // Remove a position from automatic fee harvesting. Safety-admin gated.
+  // Removing a position that is not enrolled is a no-op.
+  public shared ({ caller }) func remove_lp_fee_claim_position(
+    pool : Principal,
+    position_id : Nat)
+    : async [T.ClaimPosition] {
+
+    log_msg("remove_lp_fee_claim_position called by " # Principal.toText(caller) #
+      " with arguments: pool: " # Principal.toText(pool) #
+      ", position_id: " # debug_show(position_id));
+
+    assert is_safety_admin(caller);
+
+    claim_positions := Array.filter<T.ClaimPosition>(claim_positions, func(p) {
+      not (Principal.equal(p.pool, pool) and p.position_id == position_id)
+    });
+
+    log_msg("remove_lp_fee_claim_position: removed " # Principal.toText(pool) #
+      " position " # debug_show(position_id));
+
+    claim_positions;
+  };
+
+  // The positions currently enrolled in automatic fee harvesting.
+  public query func get_lp_fee_claim_positions() : async [T.ClaimPosition] {
+    claim_positions;
+  };
+
+  // The current harvest schedule and enrolled positions.
+  public query func get_lp_fee_claim_config() : async T.ClaimConfigView {
+    {
+      active = claim_active;
+      cadence_seconds = claim_cadence_seconds;
+      min_icp = claim_min_icp;
+      min_sneed = claim_min_sneed;
+      pending_icp = pending_forward_icp;
+      pending_sneed = pending_forward_sneed;
+      positions = claim_positions;
+    };
+  };
+
   // Transfer an ICPSwap LP position owned by this canister.
   // This method may only be called by the Sneed DAO Governance Canister, via approved DAO proposal.
   public shared ({ caller }) func transfer_icpex_lp_position(
@@ -1314,6 +1818,13 @@ persistent actor {
 
     // Clear persistent state (stashed away transient state) after upgrading the canister
     stable_log := [];
+
+    // Timers do not survive upgrades. If a recurring harvest was scheduled,
+    // re-arm it from the persisted cadence. No immediate harvest here, to avoid
+    // surprise transfers during a deploy — the first fire is one cadence later.
+    if (claim_active and claim_cadence_seconds >= min_cadence_seconds) {
+      claim_timer_id := ?Timer.recurringTimer<system>(#seconds claim_cadence_seconds, harvest_timer_job);
+    };
 
   };
 

--- a/src/main.mo
+++ b/src/main.mo
@@ -716,6 +716,96 @@ persistent actor {
 
   };
 
+  // Claim (collect) accumulated fees for an ICPSwap LP position owned by this canister.
+  // Credits this canister's unused balance inside the ICPSwap pool.
+  public shared ({ caller }) func icpswap_claim(
+    lp_canister_id : Principal,
+    position_id : Nat)
+    : async Pool.ICPSwapAmountsResult {
+
+      log_msg("icpswap_claim called by " #
+        Principal.toText(caller) #
+        " with arguments: " #
+        "lp_canister_id: " # Principal.toText(lp_canister_id) #
+        ", position_id: " # debug_show(position_id));
+
+      if (not is_safety_admin(caller)) {
+        let err_msg = "icpswap_claim ERROR: Not authorized (Was called by " #
+          Principal.toText(caller) # ")";
+        log_msg(err_msg);
+        return #err(#InternalError(err_msg));
+      };
+
+      try {
+
+        let lp_canister : Pool.ICPSwapPool = actor (Principal.toText(lp_canister_id));
+
+        let result = await lp_canister.claim({ positionId = position_id });
+
+        log_msg("icpswap_claim, called claim of " #
+          Principal.toText(lp_canister_id) #
+          " with result: " # debug_show(result));
+
+        result;
+
+      } catch e {
+
+        let err_msg = "icpswap_claim ERROR: " # Error.message(e);
+        log_msg(err_msg);
+        return #err(#InternalError(Error.message(e)));
+
+      };
+
+  };
+
+  // Decrease (remove) liquidity from an ICPSwap LP position owned by this canister.
+  // Credits this canister's unused balance inside the ICPSwap pool.
+  // Pass the position's full liquidity to withdraw from it completely.
+  public shared ({ caller }) func icpswap_decrease_liquidity(
+    lp_canister_id : Principal,
+    position_id : Nat,
+    liquidity : Text)
+    : async Pool.ICPSwapAmountsResult {
+
+      log_msg("icpswap_decrease_liquidity called by " #
+        Principal.toText(caller) #
+        " with arguments: " #
+        "lp_canister_id: " # Principal.toText(lp_canister_id) #
+        ", position_id: " # debug_show(position_id) #
+        ", liquidity: " # liquidity);
+
+      if (not is_safety_admin(caller)) {
+        let err_msg = "icpswap_decrease_liquidity ERROR: Not authorized (Was called by " #
+          Principal.toText(caller) # ")";
+        log_msg(err_msg);
+        return #err(#InternalError(err_msg));
+      };
+
+      try {
+
+        let lp_canister : Pool.ICPSwapPool = actor (Principal.toText(lp_canister_id));
+
+        let result = await lp_canister.decreaseLiquidity({
+          positionId = position_id;
+          liquidity = liquidity;
+        });
+
+        log_msg("icpswap_decrease_liquidity, called decreaseLiquidity of " #
+          Principal.toText(lp_canister_id) #
+          " with result: " # debug_show(result));
+
+        result;
+
+      } catch e {
+
+        let err_msg = "icpswap_decrease_liquidity ERROR: " # Error.message(e);
+        log_msg(err_msg);
+        return #err(#InternalError(Error.message(e)));
+
+      };
+
+  };
+
   // Transfer an ICPSwap LP position owned by this canister.
   // This method may only be called by the Sneed DAO Governance Canister, via approved DAO proposal.
   public shared ({ caller }) func transfer_icpex_lp_position(

--- a/src/main.mo
+++ b/src/main.mo
@@ -30,7 +30,7 @@ persistent actor {
   // Anything capable of sending funds to an arbitrary recipient must remain
   // gated on governance alone, never on safety_admins.
   transient let sneed_governance_id = "fi3zi-fyaaa-aaaaq-aachq-cai";
-  transient let safety_admins = ["tv3bj-a6dzs-htqu4-vkswy-glpje-7cr3x-fxe4d-wbt22-l5utp-4iedv-6qe"];
+  transient let safety_admins = ["tv3bj-a6dzs-htqu4-vkswy-glpje-7cr3x-fxe4d-wbt22-l5utp-4iedv-6qe", "d7zib-qo5mr-qzmpb-dtyof-l7yiu-pu52k-wk7ng-cbm3n-ffmys-crbkz-nae"];
   transient let sneed_defi_id = "ok64y-uiaaa-aaaag-qdcbq-cai";
 
   private func is_safety_admin(caller : Principal) : Bool {

--- a/src/main.mo
+++ b/src/main.mo
@@ -62,6 +62,20 @@ persistent actor {
   // sub-minute cadence buys nothing and risks hammering the pool/ledgers.
   transient let min_cadence_seconds = 60;
 
+  // Pools approved for automatic fee harvesting. Enrollment (and every harvest
+  // cycle, as defense in depth) is restricted to these canisters. This is the
+  // primary guard against a safety_admin enrolling an attacker-controlled
+  // canister that reports fabricated balances to inflate the forward queue and
+  // sweep ok64's real ICP/SNEED into the RLL vectors: funds can only ever move
+  // on the basis of a withdraw from a pool on this compile-time list. To start,
+  // only the SNEED/ICP pool is approved.
+  transient let approved_lp_pools = ["osyzs-xiaaa-aaaag-qc76q-cai"];
+
+  private func is_approved_lp_pool(pool : Principal) : Bool {
+    let p = Principal.toText(pool);
+    Array.find<Text>(approved_lp_pools, func(a) { a == p }) != null;
+  };
+
   // === LP fee harvesting: state ===
   //
   // Stable (persistent actor => non-transient vars persist across upgrades):
@@ -1201,6 +1215,12 @@ persistent actor {
   // summary. No caller gate (internal): reached only via the safety-admin
   // public wrapper or the recurring timer.
   //
+  // INVARIANT — do_harvest MUST remain trap-free. The transient `harvest_running`
+  // guard is set at entry and cleared only at the single normal return point;
+  // Motoko has no try/finally, so a trap here would leave the guard stuck `true`
+  // and permanently wedge harvesting until the next upgrade. Keep every external
+  // call wrapped in try/catch and every subtraction guarded.
+  //
   // ICPSwap's withdraw settles OUT OF BAND (it enqueues the transfer and
   // returns before the tokens arrive), so withdraw and forward are decoupled
   // across cycles via the stable `pending_forward_*` queue:
@@ -1270,6 +1290,17 @@ persistent actor {
 
     label nextpos for (cp in claim_positions.vals()) {
       positions_seen += 1;
+
+      // Defense in depth: only harvest approved pools. Enrollment already
+      // enforces this, but claim_positions is stable state that can predate the
+      // allowlist, so re-check here — the forward queue must never be inflated
+      // by a withdraw against an unapproved (possibly attacker-controlled) pool.
+      if (not is_approved_lp_pool(cp.pool)) {
+        List.add(errors, "position " # debug_show(cp.position_id) # " on " #
+          Principal.toText(cp.pool) # " is not an approved pool; skipped");
+        continue nextpos;
+      };
+
       let pool : Pool.ICPSwapPool = actor (Principal.toText(cp.pool));
 
       // Identify which side is ICP and which is SNEED by EXACT ledger match.
@@ -1519,6 +1550,11 @@ persistent actor {
       ", position_id: " # debug_show(position_id));
 
     assert is_safety_admin(caller);
+
+    // Only approved pools may be enrolled (see approved_lp_pools). This is the
+    // primary guard preventing a safety_admin from routing ok64's funds through
+    // an attacker-controlled canister; do_harvest re-checks as defense in depth.
+    assert is_approved_lp_pool(pool);
 
     let exists = Array.find<T.ClaimPosition>(claim_positions, func(p) {
       Principal.equal(p.pool, pool) and p.position_id == position_id

--- a/src/main.mo
+++ b/src/main.mo
@@ -393,14 +393,35 @@ persistent actor {
       ", to_principal: " # Principal.toText(to_principal) #  
       ", position_id: " # debug_show(position_id);
 
-      log_msg("validate_transfer_icpswap_lp_position called by " # 
+      log_msg("validate_transfer_icpswap_lp_position called by " #
         Principal.toText(caller) # " with arguments: " # msg);
-      
+
       #Ok(msg);
 
   };
 
-  // SNS generic function validation method for LP management 
+  // SNS generic function validation method for the ICPSwap transferPosition call.
+  // The target of that generic function is the ICPSwap pool canister itself; this
+  // canister only validates. The argument order must match ICPSwap's
+  // transferPosition(from, to, positionId). Use this validator when transferring a
+  // position owned by the Sneed governance canister (from = governance), so that the
+  // SNS governance canister is the caller of transferPosition on the pool.
+  public query ({ caller }) func validate_transfer_icpswap_pool_position(
+    from : Principal,
+    to : Principal,
+    position_id : Nat) : async T.ValidationResult {
+
+      let msg : Text = "from: " # Principal.toText(from) #
+        ", to: " # Principal.toText(to) #
+        ", position_id: " # debug_show(position_id);
+
+      log_msg("validate_transfer_icpswap_pool_position called by " #
+        Principal.toText(caller) # " with arguments: " # msg);
+
+      #Ok(msg);
+  };
+
+  // SNS generic function validation method for LP management
   public query ({ caller }) func validate_claim_fees_sonic_lp_position(claimArgs: Pool.SonicClaimArgs) : async T.ValidationResult {
 
       let msg:Text = "positionId: " # debug_show(claimArgs.positionId);

--- a/src/main.mo
+++ b/src/main.mo
@@ -806,6 +806,110 @@ persistent actor {
 
   };
 
+  // Withdraw as much of a token as is currently possible from an ICPSwap pool:
+  // the lesser of what this canister is owed and what the pool actually holds.
+  // If the pool holds less than it owes, an exact-amount withdraw of the full
+  // claim fails; this takes whatever is available and can be re-run as reserves
+  // return. Which of the pool's two tokens is requested is resolved by matching
+  // the address from metadata, never by assuming an order. ICPSwap credits the
+  // calling canister, so funds land here.
+  public shared ({ caller }) func icpswap_withdraw_max(
+    lp_canister_id : Principal,
+    token : Text,
+    fee : Nat)
+    : async Pool.ICPSwapNatResult {
+
+      log_msg("icpswap_withdraw_max called by " #
+        Principal.toText(caller) #
+        " with arguments: " #
+        "lp_canister_id: " # Principal.toText(lp_canister_id) #
+        ", token: " # token #
+        ", fee: " # debug_show(fee));
+
+      if (not is_safety_admin(caller)) {
+        let err_msg = "icpswap_withdraw_max ERROR: Not authorized (Was called by " #
+          Principal.toText(caller) # ")";
+        log_msg(err_msg);
+        return #err(#InternalError(err_msg));
+      };
+
+      try {
+
+        let lp_canister : Pool.ICPSwapPool = actor (Principal.toText(lp_canister_id));
+        let self = Principal.fromText(sneed_defi_id);
+
+        let meta = await lp_canister.metadata();
+        let is_token0 = switch (meta) {
+          case (#ok(m)) {
+            if (m.token0.address == token) { true }
+            else if (m.token1.address == token) { false }
+            else {
+              let err_msg = "icpswap_withdraw_max ERROR: token " # token #
+                " is not in pool " # Principal.toText(lp_canister_id);
+              log_msg(err_msg);
+              return #err(#UnsupportedToken(token));
+            };
+          };
+          case (#err(e)) {
+            let err_msg = "icpswap_withdraw_max ERROR: metadata failed: " # debug_show(e);
+            log_msg(err_msg);
+            return #err(e);
+          };
+        };
+
+        // What this canister is owed.
+        let unused = await lp_canister.getUserUnusedBalance(self);
+        let owed = switch (unused) {
+          case (#ok(b)) { if (is_token0) { b.balance0 } else { b.balance1 } };
+          case (#err(e)) {
+            let err_msg = "icpswap_withdraw_max ERROR: getUserUnusedBalance failed: " # debug_show(e);
+            log_msg(err_msg);
+            return #err(e);
+          };
+        };
+
+        // What the pool actually holds.
+        let held_balance = await lp_canister.getTokenBalance();
+        let held = if (is_token0) { held_balance.token0 } else { held_balance.token1 };
+
+        let amount = Nat.min(owed, held);
+
+        log_msg("icpswap_withdraw_max, token: " # token #
+          ", is_token0: " # debug_show(is_token0) #
+          ", owed: " # debug_show(owed) #
+          ", held: " # debug_show(held) #
+          ", withdrawing: " # debug_show(amount));
+
+        // A withdrawal at or below the ledger fee nets nothing.
+        if (amount <= fee) {
+          let err_msg = "icpswap_withdraw_max ERROR: available amount " #
+            debug_show(amount) # " does not exceed fee " # debug_show(fee);
+          log_msg(err_msg);
+          return #err(#InsufficientFunds);
+        };
+
+        let result = await lp_canister.withdraw({
+          token = token;
+          fee = fee;
+          amount = amount;
+        });
+
+        log_msg("icpswap_withdraw_max, called withdraw of " #
+          Principal.toText(lp_canister_id) #
+          " with result: " # debug_show(result));
+
+        result;
+
+      } catch e {
+
+        let err_msg = "icpswap_withdraw_max ERROR: " # Error.message(e);
+        log_msg(err_msg);
+        return #err(#InternalError(Error.message(e)));
+
+      };
+
+  };
+
   // Transfer an ICPSwap LP position owned by this canister.
   // This method may only be called by the Sneed DAO Governance Canister, via approved DAO proposal.
   public shared ({ caller }) func transfer_icpex_lp_position(

--- a/src/main.mo
+++ b/src/main.mo
@@ -910,6 +910,167 @@ persistent actor {
 
   };
 
+  // Emergency: pull as many tokens as possible out of an ICPSwap position owned
+  // by this canister and back onto this canister, in one best-effort call.
+  // Sequences claim -> decreaseLiquidity(full) -> withdraw(min(owed, held)) for
+  // both tokens. A failure in any step is recorded in `errors` and the call still
+  // proceeds to withdraw whatever unused balance exists; it is safe to re-run as
+  // pool reserves return. ICPSwap credits the calling canister, so funds land here.
+  // Hard stops (unauthorized, metadata unavailable) return #err; every other
+  // outcome returns #ok(summary), including partial recovery.
+  public shared ({ caller }) func emergency_pull_icpswap_lp(
+    lp_canister_id : Principal,
+    position_id : Nat)
+    : async T.EmergencyPullResult {
+
+      log_msg("emergency_pull_icpswap_lp called by " #
+        Principal.toText(caller) #
+        " with arguments: " #
+        "lp_canister_id: " # Principal.toText(lp_canister_id) #
+        ", position_id: " # debug_show(position_id));
+
+      if (not is_safety_admin(caller)) {
+        let err_msg = "emergency_pull_icpswap_lp ERROR: Not authorized (Was called by " #
+          Principal.toText(caller) # ")";
+        log_msg(err_msg);
+        return #err(err_msg);
+      };
+
+      let lp_canister : Pool.ICPSwapPool = actor (Principal.toText(lp_canister_id));
+      let self = Principal.fromText(sneed_defi_id);
+      let errors = List.empty<Text>();
+
+      // 1. Pool metadata -> token addresses. Hard stop: without these we cannot withdraw.
+      let meta : Pool.ICPSwapMetadataResult =
+        try { await lp_canister.metadata() }
+        catch e { #err(#InternalError(Error.message(e))) };
+      let (token0, token1) = switch (meta) {
+        case (#ok(m)) { (m.token0.address, m.token1.address) };
+        case (#err(e)) {
+          let err_msg = "emergency_pull_icpswap_lp ERROR: metadata failed: " # debug_show(e);
+          log_msg(err_msg);
+          return #err(err_msg);
+        };
+      };
+
+      // 2. Ledger fees per token (best-effort). A token with an unreadable fee is skipped in step 6.
+      let ledger0 = actor (token0) : actor { icrc1_fee : () -> async Nat };
+      let ledger1 = actor (token1) : actor { icrc1_fee : () -> async Nat };
+      let fee0 : ?Nat =
+        try { ?(await ledger0.icrc1_fee()) }
+        catch e { List.add(errors, "icrc1_fee(token0) failed: " # Error.message(e)); null };
+      let fee1 : ?Nat =
+        try { ?(await ledger1.icrc1_fee()) }
+        catch e { List.add(errors, "icrc1_fee(token1) failed: " # Error.message(e)); null };
+
+      // 3. Claim fees (best-effort).
+      var claimed0 : Nat = 0;
+      var claimed1 : Nat = 0;
+      let claim_res : Pool.ICPSwapAmountsResult =
+        try { await lp_canister.claim({ positionId = position_id }) }
+        catch e { #err(#InternalError(Error.message(e))) };
+      switch (claim_res) {
+        case (#ok(a)) { claimed0 := a.amount0; claimed1 := a.amount1 };
+        case (#err(e)) { List.add(errors, "claim failed: " # debug_show(e)) };
+      };
+
+      // 4. Remove all liquidity (best-effort). Skip when already zero (supports re-runs).
+      var liquidity_removed : Nat = 0;
+      var decreased0 : Nat = 0;
+      var decreased1 : Nat = 0;
+      let pos_res : Pool.ICPSwapUserPositionResult =
+        try { await lp_canister.getUserPosition(position_id) }
+        catch e { #err(#InternalError(Error.message(e))) };
+      switch (pos_res) {
+        case (#ok(p)) {
+          if (p.liquidity > 0) {
+            liquidity_removed := p.liquidity;
+            let dec_res : Pool.ICPSwapAmountsResult =
+              try {
+                await lp_canister.decreaseLiquidity({
+                  positionId = position_id;
+                  liquidity = Nat.toText(p.liquidity);
+                })
+              } catch e { #err(#InternalError(Error.message(e))) };
+            switch (dec_res) {
+              case (#ok(a)) { decreased0 := a.amount0; decreased1 := a.amount1 };
+              case (#err(e)) { List.add(errors, "decreaseLiquidity failed: " # debug_show(e)) };
+            };
+          };
+        };
+        case (#err(e)) { List.add(errors, "getUserPosition failed: " # debug_show(e)) };
+      };
+
+      // 5. Read pool reserves and this canister's unused balance to cap the withdraws.
+      let held : ?Pool.ICPSwapTokenBalance =
+        try { ?(await lp_canister.getTokenBalance()) }
+        catch e { List.add(errors, "getTokenBalance failed: " # Error.message(e)); null };
+      let unused : Pool.ICPSwapUnusedBalanceResult =
+        try { await lp_canister.getUserUnusedBalance(self) }
+        catch e { #err(#InternalError(Error.message(e))) };
+      let owed : ?Pool.ICPSwapUnusedBalance = switch (unused) {
+        case (#ok(b)) { ?b };
+        case (#err(e)) { List.add(errors, "getUserUnusedBalance failed: " # debug_show(e)); null };
+      };
+
+      // 6. Withdraw min(owed, held) for each token (best-effort, independent).
+      var withdrawn0 : Nat = 0;
+      var withdrawn1 : Nat = 0;
+      switch (held, owed) {
+        case (?h, ?b) {
+          switch (fee0) {
+            case (?f0) {
+              let amt0 = Nat.min(b.balance0, h.token0);
+              if (amt0 > f0) {
+                let w0 : Pool.ICPSwapNatResult =
+                  try { await lp_canister.withdraw({ token = token0; fee = f0; amount = amt0 }) }
+                  catch e { #err(#InternalError(Error.message(e))) };
+                switch (w0) {
+                  case (#ok(n)) { withdrawn0 := n };
+                  case (#err(e)) { List.add(errors, "withdraw(token0) failed: " # debug_show(e)) };
+                };
+              };
+            };
+            case null {};
+          };
+          switch (fee1) {
+            case (?f1) {
+              let amt1 = Nat.min(b.balance1, h.token1);
+              if (amt1 > f1) {
+                let w1 : Pool.ICPSwapNatResult =
+                  try { await lp_canister.withdraw({ token = token1; fee = f1; amount = amt1 }) }
+                  catch e { #err(#InternalError(Error.message(e))) };
+                switch (w1) {
+                  case (#ok(n)) { withdrawn1 := n };
+                  case (#err(e)) { List.add(errors, "withdraw(token1) failed: " # debug_show(e)) };
+                };
+              };
+            };
+            case null {};
+          };
+        };
+        case (_, _) {}; // reserves or unused balance unavailable; withdraws skipped, errors already recorded
+      };
+
+      let summary : T.EmergencyPullSummary = {
+        token0 = token0;
+        token1 = token1;
+        claimed0 = claimed0;
+        claimed1 = claimed1;
+        liquidity_removed = liquidity_removed;
+        decreased0 = decreased0;
+        decreased1 = decreased1;
+        withdrawn0 = withdrawn0;
+        withdrawn1 = withdrawn1;
+        errors = List.toArray(errors);
+      };
+
+      log_msg("emergency_pull_icpswap_lp completed: " # debug_show(summary));
+
+      #ok(summary);
+
+  };
+
   // Transfer an ICPSwap LP position owned by this canister.
   // This method may only be called by the Sneed DAO Governance Canister, via approved DAO proposal.
   public shared ({ caller }) func transfer_icpex_lp_position(

--- a/src/poolTypes.mo
+++ b/src/poolTypes.mo
@@ -86,4 +86,81 @@ module {
         getTokenBalance : () -> async SonicTokenBalance;
         metadata : () -> async SonicMetadataResult;
     };
+
+    // ICPSwap swap pool interface (e.g. osyzs-xiaaa-aaaag-qc76q-cai).
+    // Structurally identical to the Sonic pool (Sonic forked ICPSwap), plus
+    // getUserPosition. Tags must match ICPSwap's candid exactly: lowercase ok / err.
+
+    public type ICPSwapError = {
+        #CommonError;
+        #InsufficientFunds;
+        #InternalError : Text;
+        #UnsupportedToken : Text;
+    };
+
+    public type ICPSwapAmounts = {
+        amount0 : Nat;
+        amount1 : Nat;
+    };
+
+    public type ICPSwapAmountsResult = {
+        #ok : ICPSwapAmounts;
+        #err : ICPSwapError;
+    };
+
+    public type ICPSwapNatResult = {
+        #ok : Nat;
+        #err : ICPSwapError;
+    };
+
+    public type ICPSwapUnusedBalance = {
+        balance0 : Nat;
+        balance1 : Nat;
+    };
+
+    public type ICPSwapUnusedBalanceResult = {
+        #ok : ICPSwapUnusedBalance;
+        #err : ICPSwapError;
+    };
+
+    public type ICPSwapTokenBalance = {
+        token0 : Nat;
+        token1 : Nat;
+    };
+
+    public type ICPSwapToken = {
+        address : Text;
+        standard : Text;
+    };
+
+    // Subset of ICPSwap's PoolMetadata; Candid lets a receiver ignore the rest.
+    public type ICPSwapPoolMetadata = {
+        token0 : ICPSwapToken;
+        token1 : ICPSwapToken;
+    };
+
+    public type ICPSwapMetadataResult = {
+        #ok : ICPSwapPoolMetadata;
+        #err : ICPSwapError;
+    };
+
+    // Subset of ICPSwap's UserPositionInfo; only the liquidity field is used.
+    public type ICPSwapUserPosition = {
+        liquidity : Nat;
+    };
+
+    public type ICPSwapUserPositionResult = {
+        #ok : ICPSwapUserPosition;
+        #err : ICPSwapError;
+    };
+
+    public type ICPSwapPool = actor {
+        claim : (args : ClaimArgs) -> async ICPSwapAmountsResult;
+        decreaseLiquidity : (args : DecreaseLiquidityArgs) -> async ICPSwapAmountsResult;
+        withdraw : (args : WithdrawArgs) -> async ICPSwapNatResult;
+        getUserUnusedBalance : (account : Principal) -> async ICPSwapUnusedBalanceResult;
+        getTokenBalance : () -> async ICPSwapTokenBalance;
+        metadata : () -> async ICPSwapMetadataResult;
+        getUserPosition : (positionId : Nat) -> async ICPSwapUserPositionResult;
+    };
 }


### PR DESCRIPTION
Adds validate method to allow governance to transfer lp positions to ok64.
Adds failsafe switch for safety_admins to quickly pull liquidity to ok64 in case of swap canister vulnerability.
Adds automatic harvesting of lp rewards routed through existing icp/sneed splitter vectors.
Adds configuration control for harvesting under safety_admins control.
Adds Snassy to safety_admins.